### PR TITLE
fix: resolve runtime path and propagate clang failures in --compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,10 +77,16 @@ clean: ## Clean all build artifacts
 
 # Testing Framework
 # =============================================================================
-.PHONY: test test-all test-zig test-stdlib test-compiler test-examples
+.PHONY: test test-all test-zig test-stdlib test-compiler test-examples native-runtime-path native-clang-failure
 .PHONY: run-tests check verify
 
 test: test-zig ## Run all tests
+
+native-runtime-path: build ## Verify native compile finds runtime outside repo cwd
+	$(AT)scripts/check-native-runtime-path.sh
+
+native-clang-failure: build ## Verify native compile returns nonzero when clang fails
+	$(AT)scripts/check-native-clang-failure.sh
 
 test-zig: build ## Run Zig compiler tests
 	$(AT)echo -e "$(BLUE)🧪 Running Zig compiler tests...$(RESET)"

--- a/scripts/check-native-clang-failure.sh
+++ b/scripts/check-native-clang-failure.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+set -eu
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+source_file="$tmpdir/clang-failure.💀"
+output_file="$tmpdir/clang-failure"
+fake_bin="$tmpdir/bin"
+mkdir -p "$fake_bin"
+
+cat >"$source_file" <<'EOF'
+vibe main
+yeet "vibez"
+
+slay main_character() {
+    vibez.spill("clang-failure")
+}
+EOF
+
+cat >"$fake_bin/clang" <<'EOF'
+#!/bin/sh
+printf '%s\n' 'fake clang failure' >&2
+exit 42
+EOF
+chmod +x "$fake_bin/clang"
+
+set +e
+PATH="$fake_bin:$PATH" ./zig-out/bin/cursed-compiler --compile --output="$output_file" "$source_file" >"$tmpdir/stdout" 2>"$tmpdir/stderr"
+status=$?
+set -e
+
+if [ "$status" -eq 0 ]; then
+    printf '%s\n' 'expected cursed-compiler --compile to fail when clang fails' >&2
+    printf '%s\n' 'stdout:' >&2
+    cat "$tmpdir/stdout" >&2
+    printf '%s\n' 'stderr:' >&2
+    cat "$tmpdir/stderr" >&2
+    exit 1
+fi
+
+if [ -e "$output_file" ]; then
+    printf '%s\n' "expected no output binary at $output_file" >&2
+    exit 1
+fi
+
+if ! grep -Eq 'fake clang failure|ClangFailed|Compilation failed' "$tmpdir/stderr"; then
+    printf '%s\n' 'expected clang failure diagnostics on stderr' >&2
+    cat "$tmpdir/stderr" >&2
+    exit 1
+fi

--- a/scripts/check-native-runtime-path.sh
+++ b/scripts/check-native-runtime-path.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
+compiler="$repo_root/zig-out/bin/cursed-compiler"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+source_file="$tmpdir/runtime-path.💀"
+output_file="$tmpdir/runtime-path"
+
+cat >"$source_file" <<'EOF'
+vibe main
+yeet "vibez"
+
+slay main_character() {
+    vibez.spill("cwd-runtime")
+}
+EOF
+
+set +e
+(
+    cd "$tmpdir"
+    "$compiler" --compile --output="$output_file" "$source_file" >"$tmpdir/stdout" 2>"$tmpdir/stderr"
+)
+status=$?
+set -e
+
+if [ "$status" -ne 0 ]; then
+    printf '%s\n' "expected native compile to work from cwd $tmpdir" >&2
+    printf 'exit=%s\n' "$status" >&2
+    cat "$tmpdir/stderr" >&2
+    exit 1
+fi
+
+if [ ! -x "$output_file" ]; then
+    printf '%s\n' "expected output binary at $output_file" >&2
+    cat "$tmpdir/stderr" >&2
+    exit 1
+fi
+
+"$output_file" >"$tmpdir/run.stdout" 2>"$tmpdir/run.stderr"
+printf '%s\n' 'cwd-runtime' >"$tmpdir/expected.stdout"
+
+if ! cmp -s "$tmpdir/expected.stdout" "$tmpdir/run.stdout"; then
+    printf '%s\n' 'unexpected run stdout' >&2
+    cat "$tmpdir/run.stdout" >&2
+    exit 1
+fi
+
+if grep -q '/home/ghuntley' "$tmpdir/stderr"; then
+    printf '%s\n' 'native compile used maintainer-specific runtime path' >&2
+    cat "$tmpdir/stderr" >&2
+    exit 1
+fi
+
+if ! grep -q 'src-zig/cursed_runtime.c' "$tmpdir/stderr"; then
+    printf '%s\n' 'native compile diagnostics did not show runtime source path' >&2
+    cat "$tmpdir/stderr" >&2
+    exit 1
+fi

--- a/src-zig/llvm_ir_pipeline_complete.zig
+++ b/src-zig/llvm_ir_pipeline_complete.zig
@@ -10,12 +10,14 @@ const lexer = @import("lexer.zig");
 const parser = @import("parser.zig");
 
 // Define explicit error set to avoid circular dependencies
-const CompileError = error{ 
-    OutOfMemory, 
+const CompileError = error{
+    OutOfMemory,
     InvalidExpression,
     UnsupportedFeature,
     VariableNotFound,
     FunctionNotFound,
+    ClangUnavailable,
+    ClangFailed,
 };
 
 // Use Zig's built-in LLVM IR builder (cross-platform, no C dependencies)
@@ -4281,7 +4283,7 @@ pub const LLVMIRPipeline = struct {
         }) catch |err| {
             print("❌ Failed to run clang: {any}\n", .{err});
             print("💡 Make sure clang is installed and accessible\n", .{});
-            return;
+            return CompileError.ClangUnavailable;
         };
         defer self.allocator.free(result.stdout);
         defer self.allocator.free(result.stderr);
@@ -4298,6 +4300,7 @@ pub const LLVMIRPipeline = struct {
                 print("Error output: {s}\n", .{result.stderr});
             }
             print("💡 LLVM IR saved for debugging: {s}\n", .{ir_file});
+            return CompileError.ClangFailed;
         }
     }
 

--- a/src-zig/llvm_ir_pipeline_complete.zig
+++ b/src-zig/llvm_ir_pipeline_complete.zig
@@ -4263,9 +4263,9 @@ pub const LLVMIRPipeline = struct {
             try self.allocator.dupe(u8, output_file);
         defer self.allocator.free(exe_name);
         
-        // Step 3: Automatically invoke clang to compile to native binary
-        // Use absolute path to runtime to work from any directory
-        const runtime_path = "/home/ghuntley/cursed/src-zig/cursed_runtime.c";
+        // Step 3: Automatically invoke clang to compile to native binary.
+        const runtime_path = try self.resolveRuntimePath();
+        defer self.allocator.free(runtime_path);
         
         const compile_cmd = try std.fmt.allocPrint(self.allocator, 
             "clang -O2 -o {s} {s} {s}", .{ exe_name, ir_file, runtime_path });
@@ -4299,6 +4299,21 @@ pub const LLVMIRPipeline = struct {
             }
             print("💡 LLVM IR saved for debugging: {s}\n", .{ir_file});
         }
+    }
+
+    fn resolveRuntimePath(self: *Self) ![]u8 {
+        const exe_dir = try std.fs.selfExeDirPathAlloc(self.allocator);
+        defer self.allocator.free(exe_dir);
+
+        // In the source-checkout build, the compiler lives at zig-out/bin
+        // and the runtime source is kept in the checkout's src-zig directory.
+        return try std.fs.path.resolve(self.allocator, &[_][]const u8{
+            exe_dir,
+            "..",
+            "..",
+            "src-zig",
+            "cursed_runtime.c",
+        });
     }
     
     // ========================= NEW STATEMENT IMPLEMENTATIONS =========================


### PR DESCRIPTION
Fixes #14

This PR fixes two native compilation bugs in the `zig` branch:

- resolves `src-zig/cursed_runtime.c` relative to the compiler location instead of using the hardcoded `/home/ghuntley/cursed/...` path
- returns a real error when `clang` cannot be launched or exits nonzero, instead of falling through with exit status `0`

Why this change:

- `--compile` currently only works from a checkout that happens to live at `/home/ghuntley/cursed`
- `--compile` can currently report a clang failure but still exit successfully without producing a binary

Tests:

- `make native-runtime-path`
- `make native-clang-failure`

Notes:

- this fixes the checkout-path bug for source builds on `zig`
- standalone release binaries may still need a follow-up for runtime lookup outside a source checkout
